### PR TITLE
修改Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
 COPY --from=buildpack /usr/local/lib/libgmssl.* /usr/local/lib/
-RUN ldconfig
-
 COPY --from=buildpack /etc/nginx /etc/nginx
 COPY --from=buildpack /usr/local/sbin/nginx /usr/local/sbin/nginx
 COPY --from=buildpack /usr/local/nginx /usr/local/nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,70 @@
-#Nginx-with-GmSSLv3
-FROM ubuntu:20.04
+FROM buildpack-deps:stable as buildpack
+
 LABEL org.opencontainers.image.authors="zhaopku09@gmail.com"
 
-USER root
-RUN DEBIAN_FRONTEND=noninteractive 
-RUN mv /etc/apt/sources.list /etc/apt/sources_backup.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal main restricted " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-updates main restricted " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal universe " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-updates universe " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal multiverse " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-updates multiverse " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-backports main restricted universe multiverse " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-security main restricted " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-security universe " >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.ustc.edu.cn/ubuntu/ focal-security multiverse " >> /etc/apt/sources.list && \
-    echo "deb http://archive.canonical.com/ubuntu focal partner " >> /etc/apt/sources.list
+RUN apt-get update \
+    && apt-get install -y cmake
 
-RUN apt-get update -y
-RUN apt-get install tzdata
-RUN apt-get install git libpcre3 libpcre3-dev zlib1g zlib1g-dev unzip wget cmake build-essential -yqq 
-RUN git clone https://github.com/guanzhi/GmSSL.git
-WORKDIR /build
-RUN cmake /GmSSL/.
-RUN make install
+WORKDIR /tmp/build
+
+# Build GmSSL lib
+COPY GmSSL /tmp/build/GmSSL
+
+RUN cmake ./GmSSL/. \
+    && make install \
+    && ldconfig
+
+# Build nginx
+COPY . /tmp/build/nginx
+
+RUN cd nginx \
+    && cp auto/configure . \
+    && ./configure \
+    --sbin-path=/usr/local/sbin/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --error-log-path=/var/log/nginx/error.log \
+    --pid-path=/var/run/nginx/nginx.pid \
+    --lock-path=/var/lock/nginx/nginx.lock \
+    --http-log-path=/var/log/nginx/access.log \
+    --http-client-body-temp-path=/tmp/nginx-client-body \
+    --with-http_ssl_module \
+    --without-http_upstream_zone_module \
+    --with-debug \
+    && make -j $(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && mkdir /var/lock/nginx \
+    && rm -rf /tmp/build
+
+
+## Export to end-images
+FROM debian:stable-slim
+
+ENV TZ=Asia/Shanghai
+
+RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone
+
+COPY --from=buildpack /usr/local/lib/libgmssl.* /usr/local/lib/
 RUN ldconfig
-WORKDIR /Nginx-with-GmSSLv3
-RUN ls /usr/local/bin
-COPY . .
-RUN cp auto/configure .
-RUN ./configure --with-http_ssl_module --without-http_upstream_zone_module --with-debug
-RUN make
-RUN make install
-#默认配置文件
-COPY ./conf/nginx_ssl.conf /usr/local/nginx/conf/nginx.conf
+
+COPY --from=buildpack /etc/nginx /etc/nginx
+COPY --from=buildpack /usr/local/sbin/nginx /usr/local/sbin/nginx
+COPY --from=buildpack /usr/local/nginx /usr/local/nginx
+
+# Reload lib cache & make nginx run directories
+RUN ldconfig \
+    && mkdir -p /var/lock/nginx \
+    && mkdir -p /var/log/nginx \
+    mkdir -p /var/run/nginx
+
+# Forward logs to Docker
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+# Set up config file
+COPY conf/nginx_ssl.conf /etc/nginx/conf/nginx.conf
+
 EXPOSE 443/tcp
 EXPOSE 80/tcp
-ENV PATH="/usr/local/nginx/sbin:${PATH}"
-CMD ["/bin/sh","-c","nginx -g 'daemon off;'"]
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
1. 使用buildpack-deps进行构建
2. 使用multi-stage方法，将build拷贝到结果镜像。最终镜像大小87.41MB。
3. 建议将nginx的文件放到nginx-gmssl子目录，这样比较符合docker的COPY。